### PR TITLE
"/docker-entrypoint.sh: unset: line 17: 0: bad variable name"

### DIFF
--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ ! -f "/etc/ssl/dhparam.pem" ]; then
   RES=$?
   # curl returned error, generate dhparams ourselves
   if [ ${RES} -ne 0 ];then /usr/bin/openssl dhparam -out /etc/ssl/dhparam.pem 2048 ;fi
-  unset ${RES}
+  unset RES
   echo "Done"
 fi
 


### PR DESCRIPTION
Fixes error on startup, I presume this is what you meant to write, I haven't paid much attention to the script itself :)

Have built and done basic test that the container goes up and 403s a bad request.