### PR TITLE
Let's Encrypt File Permissions - archive Directory

### DIFF
--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -20,7 +20,7 @@ fi
 
 # fix Let's Encrypt's key files permissions
 if [ -d /etc/letsencrypt/live ]; then
-    chmod o+rx /etc/letsencrypt/archive
+    [ -d /etc/letsencrypt/archive ] && chmod o+rx /etc/letsencrypt/archive
     chmod o+rx /etc/letsencrypt/live
     chown .nginx /etc/letsencrypt/live/*/privkey.pem
     chmod g+r /etc/letsencrypt/live/*/privkey.pem


### PR DESCRIPTION
My certbot deployment doesn't have an archive folder at some point in the process, causing the renewal to fail as my server crashes. I've wrapped this in a test for the existence of the directory.